### PR TITLE
Use `reload4j` instead of `log4j`

### DIFF
--- a/maddash-server/maddash-server/jsnow/pom.xml
+++ b/maddash-server/maddash-server/jsnow/pom.xml
@@ -17,9 +17,9 @@
         </dependency>
         <!-- logging -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.9</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>1.2.25</version>
         </dependency>
         <!-- JSON -->
         <dependency>

--- a/maddash-server/maddash-server/maddash-server/pom.xml
+++ b/maddash-server/maddash-server/maddash-server/pom.xml
@@ -105,9 +105,9 @@
 
     <!-- logging -->
     <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.9</version>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>1.2.25</version>
     </dependency>
 
     <!-- command execution -->


### PR DESCRIPTION
Apache `log4j` version 1.x is unsupported and has several known vulnerabilities. While these vulnerabilities are not exploitable within the context of  MaDDash, vulnerability scanning tools, like Nessus, will still issues warnings about its use, creating an additional workload for system administration and security staff.

The commit included in this pull request aims to fix this issue by replacing `log4j` with `reload4j`. The `reload4j` library is a drop-in replacement for `log4j` version 1.x that is still supported and does not suffer from the vulnerabilities that `log4j` is known to have. The `reload4j` project has several well-known users and sponsors and is effectively a continuation of the `log4j` project. Please read more about the `reload4j` project here: https://reload4j.qos.ch/

This change has been tested in a small test setup consisting of several perfSONAR nodes and an archive/MaDDash server. All MaDDash logging functionality appears to be working correctly, and all other functionality appears to be working correctly as well.

Comments, questions, or concerns are welcome! Additionally, please let me know if this pull request should be opened against a different branch.

This fixes #103.